### PR TITLE
Do not fail building file list if files_add inventory variables are absent (closes #14)

### DIFF
--- a/tasks/make-files.yml
+++ b/tasks/make-files.yml
@@ -49,4 +49,7 @@
   loop_control:
     label: "{{ item.value + '/' + item.key }}"
   register: openwrt_make_files_rsync
+  when:
+    - openwrt_make_files_list is defined
+    - openwrt_make_files_list | length > 0
   delegate_to: localhost


### PR DESCRIPTION
Do not fail building file list when `openwrt_files_add` or `openwrt_software.files_add` variables are absent.