### PR TITLE
Split files per host during make (closes #13)

### DIFF
--- a/tasks/make-files.yml
+++ b/tasks/make-files.yml
@@ -5,14 +5,16 @@
 - name: "Make | Files | Remove the existing files in workdir"
   file:
     path:  "{{ openwrt_paths['workdir'] + '/' +
-               openwrt_vars['download_archive'] + '/files' }}"
+               openwrt_vars['download_archive'] + '/files/' +
+               inventory_hostname }}"
     state: absent
   delegate_to: localhost
 
 - name: "Make | Files | Create the files directory in workdir"
   file:
     path:  "{{ openwrt_paths['workdir'] + '/' +
-               openwrt_vars['download_archive'] + '/files' }}"
+               openwrt_vars['download_archive'] + '/files/' +
+               inventory_hostname }}"
     state: directory
   delegate_to: localhost
 
@@ -44,7 +46,7 @@
   shell: >
     rsync -avh --checksum --relative
     {{ openwrt_paths['files'] | realpath + '/' + item.value + '/./' + item.key }}
-    {{ openwrt_paths['workdir'] + '/' + openwrt_vars['download_archive'] + '/files' }}
+    {{ openwrt_paths['workdir'] + '/' + openwrt_vars['download_archive'] + '/files/' + inventory_hostname }}
   loop: "{{ openwrt_make_files_list }}"
   loop_control:
     label: "{{ item.value + '/' + item.key }}"

--- a/tasks/make-image.yml
+++ b/tasks/make-image.yml
@@ -8,13 +8,14 @@
       PROFILE="{{ openwrt_device['profile'] }}"
       EXTRA_IMAGE_NAME="{{ openwrt_image['extra_name'] }}"
       PACKAGES="{% if openwrt_pkgs_add | length > 0 %}{{ openwrt_pkgs_add | join(' ') }}{% endif %}{% if openwrt_pkgs_del | length > 0 %} -{{ openwrt_pkgs_del | join(' -') }}{% endif %}"
-      FILES="files"
+      FILES="files/{{ inventory_hostname }}"
   delegate_to: localhost
 
 - name: "Make | Image | Create the workdir files directory"
   file:
     path:  "{{ openwrt_paths['workdir'] + '/' +
-               openwrt_vars['download_archive'] + '/files' }}"
+               openwrt_vars['download_archive'] + '/files/' +
+               inventory_hostname }}"
     state: directory
   delegate_to: localhost
 


### PR DESCRIPTION
When building images, put files in separate directories per `inventory_hostname`.