### PR TITLE
Update OpenWISP features (closes #12)

### DIFF
--- a/files/features/other.yml
+++ b/files/features/other.yml
@@ -5,11 +5,10 @@
 ################################################################################
 other:
 
-  ### Application: OpenWISP, with WolfSSL
+  ### Application: OpenWISP
   # Packages
-  # - https://openwrt.org/packages/pkgdata/openwisp-config-wolfssl (13kB)
+  # - https://openwrt.org/packages/pkgdata/openwisp-config (14kB)
   # Dependencies
-  # - https://openwrt.org/packages/pkgdata/libwolfssl5.2.0.99a5b54a (518kB)
   # - https://openwrt.org/packages/pkgdata/ca-certificates (122kB)
   # - https://openwrt.org/packages/pkgdata/curl (52kB)
   # - https://openwrt.org/packages/pkgdata/libcurl (?kB)
@@ -23,30 +22,7 @@ other:
   # - https://openwisp.io/docs/index.html
   # - https://github.com/openwisp/luci-openwisp
   # - https://github.com/openwisp/openwisp-config
-  other-openwisp-wolfssl:
+  other-openwisp-config:
     pkgs_luci: []
-    pkgs_uci: [ 'openwisp-config-wolfssl' ]
-    files: [ 'other/openwisp' ]
-
-  ### Application: OpenWISP, with OpenSSL
-  # Packages
-  # - https://openwrt.org/packages/pkgdata/openwisp-config-openssl (13kB)
-  # Dependencies
-  # - https://openwrt.org/packages/pkgdata/libopenssl1.1 (1265kB)
-  # - https://openwrt.org/packages/pkgdata/ca-certificates (122kB)
-  # - https://openwrt.org/packages/pkgdata/curl (52kB)
-  # - https://openwrt.org/packages/pkgdata/libcurl (?kB)
-  # - https://openwrt.org/packages/pkgdata/luci-lib-nixio (28kB)
-  # - https://openwrt.org/packages/pkgdata/luafilesystem (5kB)
-  # - https://openwrt.org/packages/pkgdata/liblua5.1.5 (76kB)
-  # - https://openwrt.org/packages/pkgdata/libuci-lua (7kB)
-  # - https://openwrt.org/packages/pkgdata/libuci20130104 (17kB)
-  # Docs
-  # - https://openwisp.org/whatis.html
-  # - https://openwisp.io/docs/index.html
-  # - https://github.com/openwisp/luci-openwisp
-  # - https://github.com/openwisp/openwisp-config
-  other-openwisp-openssl:
-    pkgs_luci: []
-    pkgs_uci: [ 'openwisp-config-openssl' ]
+    pkgs_uci: [ 'openwisp-config' ]
     files: [ 'other/openwisp' ]


### PR DESCRIPTION
The OpenWISP config packages have changed.
They have been streamlined into a single package and no more variants.
- https://openwrt.org/packages/table/start?dataflt%5BName_pkg-dependencies*%7E%5D=openwisp
- https://github.com/openwisp/openwisp-config/releases/tag/1.0.0
- https://github.com/openwisp/openwisp-config/pull/152